### PR TITLE
解决httpclient版本冲突问题, 添加文档翻遍后续其他用户快速排除此类问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # KSC SDK for Java 
-  
- ## Table of Contents
+
+## Table of Contents
 * Requirements
 * Usage
 * API Dosc
+* Note
 
 ### Requirements ###
 运行 SDK需要jdk **Java 1.6+**. 你可以下载最新的版本： http://developers.sun.com/downloads/.
@@ -99,3 +100,9 @@ AWSCredentials credentials = new BasicAWSCredentials(aws_access_key_id, aws_secr
 [VCSOpenAPI]: https://www.ksyun.com/doc/cat/id/443
 [ksc-sdk-java-github]: https://github.com/KscSDK/ksc-sdk-java
 [example]: https://github.com/KscSDK/ksc-sdk-java/blob/master/README_SAMPLE.md
+
+## Note
+
+* httpclient 建议不要手动指定httpclient版本,依赖ksc-sdk-java工程管理的httpclient版本即可, 确实需要指定的话, 版本至少是4.4
+
+


### PR DESCRIPTION
```java
 Exception in thread "main" java.lang.NoSuchMethodError: org.apache.http.conn.ssl.SSLConnectionSocketFactory.<init>(Ljavax/net/ssl/SSLContext;Ljavax/net/ssl/HostnameVerifier;)V
at com.ksc.http.conn.ssl.SdkTLSSocketFactory.<init>(SdkTLSSocketFactory.java:58)
at com.ksc.http.apache.client.impl.ApacheConnectionManagerFactory.getPreferredSocketFactory(ApacheConnectionManagerFactory.java:91)
at com.ksc.http.apache.client.impl.ApacheConnectionManagerFactory.create(ApacheConnectionManagerFactory.java:65)
at com.ksc.http.apache.client.impl.ApacheConnectionManagerFactory.create(ApacheConnectionManagerFactory.java:58)
at com.ksc.http.apache.client.impl.ApacheHttpClientFactory.create(ApacheHttpClientFactory.java:49)
at com.ksc.http.apache.client.impl.ApacheHttpClientFactory.create(ApacheHttpClientFactory.java:38)
at com.ksc.http.KSCHttpClient.<init>(KSCHttpClient.java:250)
at com.ksc.KscWebServiceClient.<init>(KscWebServiceClient.java:143)
at com.ksc.KscWebServiceClient.<init>(KscWebServiceClient.java:134)
at com.ksc.KscWebServiceClient.<init>(KscWebServiceClient.java:119)
at com.ksc.offline.KSCOFFJsonClient.<init>(KSCOFFJsonClient.java:164)
at com.ksc.offline.KSCOFFJsonClient.<init>(KSCOFFJsonClient.java:145)
at mtime.live.platform.service.stream.TestTransfer.main(TestTransfer.java:35)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```