### PR TITLE
use PropertyNamingStrategy's static field instead of new its subclass

### DIFF
--- a/ksc-sdk-java-core/src/main/java/com/ksc/transform/JsonErrorUnmarshaller.java
+++ b/ksc-sdk-java-core/src/main/java/com/ksc/transform/JsonErrorUnmarshaller.java
@@ -17,7 +17,7 @@ package com.ksc.transform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.PascalCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.ksc.KscServiceException;
 import com.ksc.annotation.SdkInternalApi;
 import com.ksc.annotation.ThreadSafe;
@@ -34,7 +34,7 @@ public class JsonErrorUnmarshaller extends AbstractErrorUnmarshaller<JsonNode> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().configure(
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).setPropertyNamingStrategy(
-            new PascalCaseStrategy());
+            PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE);
 
     private final String handledErrorCode;
 


### PR DESCRIPTION
jackson的PropertyNamingStrategy类存在潜在的类初始化死锁的问题。
可以直接使用PropertyNamingStrategy中定义好的strategy对象，这样修改后，总是先加载父类再加载子类，不会死锁，能绕过这个问题

参考: https://github.com/FasterXML/jackson-databind/issues/2715